### PR TITLE
Enable webhook, suppress "Server" header and add labels for ServiceMonitor

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -25,6 +25,7 @@ controller:
 
   config:
     enable-modsecurity: "true"
+    server-tokens: "false"
     custom-http-errors: 413,502,503,504
     generate-request-id: "true"
     proxy-buffer-size: "16k"
@@ -98,6 +99,8 @@ controller:
     serviceMonitor:
       enabled: true
       namespace: ingress-controllers
+      additionalLabels:
+        release: prometheus-operator
 
 %{ if default_cert != "" }
   extraArgs:

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -89,7 +89,38 @@ controller:
     enabled: true
   
   admissionWebhooks:
-    enabled: false
+    annotations: {}
+    enabled: true
+    failurePolicy: Fail
+    # timeoutSeconds: 10
+    port: 8443
+    certificate: "/usr/local/certificates/cert"
+    key: "/usr/local/certificates/key"
+    namespaceSelector: {}
+    objectSelector: {}
+
+    service:
+      annotations: {}
+      # clusterIP: ""
+      externalIPs: []
+      # loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 443
+      type: ClusterIP
+
+    patch:
+      enabled: true
+      image:
+        repository: docker.io/jettech/kube-webhook-certgen
+        tag: v1.5.0
+        pullPolicy: IfNotPresent
+      ## Provide a priority class name to the webhook patching job
+      ##
+      priorityClassName: ""
+      podAnnotations: {}
+      nodeSelector: {}
+      tolerations: []
+      runAsUser: 2000
 
   stats:
     enabled: true

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -24,8 +24,7 @@ controller:
     timeoutSeconds: 5
 
   config:
-    enable-modsecurity: "true"
-    server-tokens: "false"
+    enable-modsecurity: "false"
     custom-http-errors: 413,502,503,504
     generate-request-id: "true"
     proxy-buffer-size: "16k"


### PR DESCRIPTION
This PR is to 
keep it in sync with latest default ingress controller changes like `server-token` and serviceMonitor labels
Enable webhook and upgrade to 1.5.0 which has fix for POST API latency