### PR TITLE
Add nodeAffinity and tolerations to the fallback ingress controller

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "helm_release" "k8s_ingress_nginx" {
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     controller_name = var.controller_name
     default_cert    = var.default_cert
+    enable_ingress_controller_affinity_and_tolerations = var.enable_ingress_controller_affinity_and_tolerations
     replica_count   = var.replica_count
   })]
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -12,6 +12,31 @@ controller:
 
   ingressClass: ${controller_name}
   electionID: ingress-controller-leader-${controller_name}
+%{ if enable_ingress_controller_affinity_and_tolerations ~}
+  ## Tolerations for use with node taints
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations:
+    - key: "ingress-node"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+
+  ## Assign custom affinity rules to the Ingress controller instance
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kops.k8s.io/instancegroup
+            operator: In
+            values:
+            - ingress-nodes-1.17.12-eu-west-2a
+            - ingress-nodes-1.17.12-eu-west-2b
+            - ingress-nodes-1.17.12-eu-west-2c
+%{ endif ~}
 
   livenessProbe:
     initialDelaySeconds: 20

--- a/variables.tf
+++ b/variables.tf
@@ -31,3 +31,8 @@ variable "enable_fallback_ingress_controller" {
   default     = false
   type        = bool
 }
+variable "enable_ingress_controller_affinity_and_tolerations" {
+    description = "Enable or not Ingress Controller node affinity (check helm values for the expressions)"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Add nodeAffinity and tolerations to the fallback so the ingress controller pods are scheduled on the new instanceGroup. This is to test connection TIMEOUT issue and will be reverted back later